### PR TITLE
build: build with libXft

### DIFF
--- a/layers/layer1_scientific/0008_pango/Makefile.mk
+++ b/layers/layer1_scientific/0008_pango/Makefile.mk
@@ -23,7 +23,7 @@ all::$(PREFIX)/lib/libpango-1.0.so
 $(PREFIX)/lib/libpango-1.0.so:
 	mkdir -p $(PREFIX)/../core/opt/python3_core/bin/
 	cp $(PREFIX)/../python2_core/bin/python3_wrapper $(PREFIX)/../core/opt/python3_core/bin/python3
-	$(MAKE) --file=$(MFEXT_HOME)/share/Makefile.standard PREFIX=$(PREFIX) OPTIONS="--without-xft" download uncompress configure build install
+	$(MAKE) --file=$(MFEXT_HOME)/share/Makefile.standard PREFIX=$(PREFIX) download uncompress configure build install
 	rm -r $(PREFIX)/../core/opt/
 	#cd build/$(NAME)-$(VERSION) && meson --prefix=$(PREFIX) .. && ninja && ninja install
 	


### PR DESCRIPTION
Close: #48 
libXft is now a dependency from tcltk layer in mfext, so this is no longer a problem to build pango with it in mfextaddon_scientific