### PR TITLE
feat: upgrade Pillow from 6.2.0 to 6.2.2 to fix security alerts

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -103,8 +103,8 @@
 | [pandas](http://pandas.pydata.org) | 0.24.2 | python3_scientific |
 | [pango](https://pango.gnome.org/) | 1.42.4 | scientific |
 | [pathlib](https://pathlib.readthedocs.org/) | 1.0.1 | python2_scientific |
-| [Pillow](http://python-pillow.org) | 6.2.0 | python2_scientific |
-| [Pillow](http://python-pillow.org) | 6.2.0 | python3_scientific |
+| [Pillow](http://python-pillow.org) | 6.2.2 | python2_scientific |
+| [Pillow](http://python-pillow.org) | 6.2.2 | python3_scientific |
 | [Pint](https://github.com/hgrecco/pint) | 0.9 | python2_scientific |
 | [Pint](https://github.com/hgrecco/pint) | 0.9 | python3_scientific |
 | [pngquant](https://github.com/Brightcells/pngquant) | 1.0.6 | python2_scientific |

--- a/layers/layer4_python2_scientific/0499_extra_packages/requirements2.txt
+++ b/layers/layer4_python2_scientific/0499_extra_packages/requirements2.txt
@@ -37,7 +37,7 @@ numcodecs==0.6.3
 palettable==3.2.0
 pandas==0.24.2
 pathlib==1.0.1
-Pillow==6.2.0
+Pillow==6.2.2
 Pint==0.9
 pngquant==1.0.6
 pooch==0.5.2

--- a/layers/layer4_python3_scientific/0499_extra_packages/requirements3.txt
+++ b/layers/layer4_python3_scientific/0499_extra_packages/requirements3.txt
@@ -37,7 +37,7 @@ netCDF4==1.5.1.2
 numcodecs==0.6.3
 palettable==3.2.0
 pandas==0.24.2
-Pillow==6.2.0
+Pillow==6.2.2
 Pint==0.9
 pngquant==1.0.6
 pooch==0.5.2


### PR DESCRIPTION
Close:
https://github.com/metwork-framework/mfextaddon_scientific/network/alert/layers/layer4_python2_scientific/0499_extra_packages/requirements2.txt/Pillow/open
Close:
https://github.com/metwork-framework/mfextaddon_scientific/network/alert/layers/layer4_python3_scientific/0499_extra_packages/requirements3.txt/Pillow/open