### PR TITLE
feat: update Pillow from 6.2.2 to 7.2.0 for security reasons (only py…

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -103,7 +103,7 @@
 | [pango](https://pango.gnome.org/) | 1.42.4 | scientific |
 | [pathlib](https://pathlib.readthedocs.org/) | 1.0.1 | python2_scientific |
 | [Pillow](http://python-pillow.org) | 6.2.2 | python2_scientific |
-| [Pillow](http://python-pillow.org) | 6.2.2 | python3_scientific |
+| [Pillow](https://python-pillow.org) | 7.2.0 | python3_scientific |
 | [Pint](https://github.com/hgrecco/pint) | 0.9 | python2_scientific |
 | [Pint](https://github.com/hgrecco/pint) | 0.9 | python3_scientific |
 | [pngquant](https://github.com/Brightcells/pngquant) | 1.0.6 | python2_scientific |

--- a/layers/layer4_python3_scientific/0499_extra_packages/requirements3.txt
+++ b/layers/layer4_python3_scientific/0499_extra_packages/requirements3.txt
@@ -36,7 +36,7 @@ netCDF4==1.5.1.2
 numcodecs==0.6.3
 palettable==3.2.0
 pandas==0.24.2
-Pillow==6.2.2
+Pillow==7.2.0
 Pint==0.9
 pngquant==1.0.6
 pooch==0.5.2


### PR DESCRIPTION
…thon3 because Pillow 7 is not python2 compliant)