### PR TITLE
fix: fix python3 build for rasterio since GDAL update and upgrade udu…

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -44,6 +44,7 @@
 | [Deprecated](https://github.com/tantale/deprecated) | 1.2.10 | python3_scientific |
 | [descartes](http://bitbucket.org/sgillies/descartes/) | 1.1.0 | python3_scientific |
 | [dill](https://pypi.org/project/dill) | 0.3.3 | python3_scientific |
+| [docutils](http://docutils.sourceforge.net/) | 0.16 | python3_scientific |
 | [eccodes](https://www.ecmwf.int/en/computing/software) | 2.14.1 | python2_scientific |
 | [eccodes](https://github.com/ecmwf/eccodes-python) | 1.0.0 | python3_scientific |
 | [eccodes](https://www.ecmwf.int/en/computing/software) | 2.19.1 | scientific |
@@ -59,6 +60,8 @@
 | [Fiona](http://github.com/Toblerity/Fiona) | 1.8.13 | python2_scientific |
 | [Fiona](http://github.com/Toblerity/Fiona) | 1.8.13 | python3_scientific |
 | [Flask](https://palletsprojects.com/p/flask/) | 1.1.1 | python3_scientific |
+| [flit-core](https://github.com/takluyver/flit) | 3.0.0 | python3_scientific |
+| [flit](https://github.com/takluyver/flit) | 3.0.0 | python3_scientific |
 | [fribidi](ihttps://github.com/fribidi/fribidi/) | 1.0.5 | scientific |
 | [funcsigs](http://funcsigs.readthedocs.org) | 1.0.2 | python2_scientific |
 | [GDAL](http://www.gdal.org) | 3.0.2 | python2_scientific |
@@ -184,11 +187,11 @@
 | [trollimage](https://github.com/pytroll/trollimage) | 1.10.1 | python3_scientific |
 | [trollsift](https://github.com/pytroll/trollsift) | 0.3.3 | python2_scientific |
 | [trollsift](https://github.com/pytroll/trollsift) | 0.3.3 | python3_scientific |
-| [udunits](http://www.unidata.ucar.edu/software/udunits) | 2.2.26 | scientific |
+| [udunits](http://www.unidata.ucar.edu/software/udunits) | 2.2.28 | scientific |
 | [Werkzeug](https://palletsprojects.com/p/werkzeug/) | 0.15.4 | python3_scientific |
 | [xarray](https://github.com/pydata/xarray) | 0.11.3 | python2_scientific |
 | [xarray](https://github.com/pydata/xarray) | 0.14.1 | python3_scientific |
 | [zarr](https://github.com/zarr-developers/zarr) | 2.3.2 | python2_scientific |
 | [zarr](https://github.com/zarr-developers/zarr) | 2.3.2 | python3_scientific |
 
-*(190 components)*
+*(193 components)*

--- a/layers/layer1_scientific/0003_udunits2/Makefile.mk
+++ b/layers/layer1_scientific/0003_udunits2/Makefile.mk
@@ -2,10 +2,10 @@ include ../../../adm/root.mk
 include $(MFEXT_HOME)/share/package.mk
 
 export NAME=udunits
-export VERSION=2.2.26
+export VERSION=2.2.28
 export EXTENSION=tar.gz
 export CHECKTYPE=MD5
-export CHECKSUM=5803837c6019236d24a9c9795cc8b462
+export CHECKSUM=58259d94f766c13b5b0cf1aed92ebbe3
 DESCRIPTION=\
 API and utility for arithmetic manipulation of units of physical quantities
 WEBSITE=http://www.unidata.ucar.edu/software/udunits

--- a/layers/layer1_scientific/0003_udunits2/sources
+++ b/layers/layer1_scientific/0003_udunits2/sources
@@ -1,1 +1,1 @@
-ftp://ftp.unidata.ucar.edu/pub/udunits/udunits-2.2.26.tar.gz
+ftp://ftp.unidata.ucar.edu/pub/udunits/udunits-2.2.28.tar.gz

--- a/layers/layer4_python3_scientific/0498_prereq_extra_packages/requirements-to-freeze.txt
+++ b/layers/layer4_python3_scientific/0498_prereq_extra_packages/requirements-to-freeze.txt
@@ -1,2 +1,5 @@
 Cython
-numpy
+#pandas 0.x doesn't build against numpy >= 1.19
+#cf https://github.com/pandas-dev/pandas/commit/6f963310787e4db4d16d308fd37f3db95eb4bb7b#diff-7896fe92978186d17a8fd289e66ac8684ad7615bb56865730ae5fb418ecb01ad
+numpy < 1.19
+flit_core

--- a/layers/layer4_python3_scientific/0498_prereq_extra_packages/requirements3.txt
+++ b/layers/layer4_python3_scientific/0498_prereq_extra_packages/requirements3.txt
@@ -1,3 +1,4 @@
 certifi==2019.3.9
 Cython==0.29.12
+flit_core==3.0.0
 numpy==1.16.4

--- a/layers/layer4_python3_scientific/0499_prereq_extra_packages/requirements-to-freeze.txt
+++ b/layers/layer4_python3_scientific/0499_prereq_extra_packages/requirements-to-freeze.txt
@@ -3,3 +3,4 @@
 #to build on centos 6 with version >= 1.2.0, we would need to build
 #atlas in version >= 3.10.0 (and maybe blas and lapack)
 scipy<1.2.0
+flit

--- a/layers/layer4_python3_scientific/0499_prereq_extra_packages/requirements3.txt
+++ b/layers/layer4_python3_scientific/0499_prereq_extra_packages/requirements3.txt
@@ -1,2 +1,4 @@
 certifi==2019.3.9
+docutils==0.16
+flit==3.0.0
 scipy==1.1.0

--- a/layers/layer4_python3_scientific/0500_extra_packages/requirements-to-freeze.txt
+++ b/layers/layer4_python3_scientific/0500_extra_packages/requirements-to-freeze.txt
@@ -18,6 +18,7 @@ pyproj==2.4.2
 SQLAlchemy
 cdsapi
 #Upgrade pandas to 1.x.x ?
+#pandas 0.x doesn't build against numpy >= 1.19
 pandas<1.0
 scikit-learn
 graphviz


### PR DESCRIPTION
…nits2 to 2.2.28 (tarball of version 2.2.26 is not available anymore)