### PR TITLE
build: python3_scientific and python3_ia are now incompatible because…

### DIFF
--- a/layers/layer4_python3_scientific/.layerapi2_conflicts
+++ b/layers/layer4_python3_scientific/.layerapi2_conflicts
@@ -1,0 +1,1 @@
+python3_ia@mfext


### PR DESCRIPTION
… python3_ia built in CentOS7 needs recent atlas/blas/lapack libraries