### PR TITLE
feat: bump Pillow from 8.1.2 to 8.2.0 to fix 6 vulnerabilities includ…

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -123,7 +123,7 @@
 | [pathos](https://pypi.org/project/pathos) | 0.2.7 | python3_scientific |
 | [pdbufr](https://github.com/ecmwf/pdbufr) | 0.8.2 | python3_scientific |
 | [Pillow](http://python-pillow.org) | 6.2.2 | python2_scientific |
-| [Pillow](https://python-pillow.org) | 8.1.2 | python3_scientific |
+| [Pillow](https://python-pillow.org) | 8.2.0 | python3_scientific |
 | [Pint](https://github.com/hgrecco/pint) | 0.9 | python2_scientific |
 | [Pint](https://github.com/hgrecco/pint) | 0.16.1 | python3_scientific |
 | [pngquant](https://github.com/Brightcells/pngquant) | 1.0.6 | python2_scientific |

--- a/layers/layer4_python3_scientific/0500_extra_packages/requirements3.txt
+++ b/layers/layer4_python3_scientific/0500_extra_packages/requirements3.txt
@@ -53,7 +53,7 @@ pandas==1.2.4
 partd==1.1.0
 pathos==0.2.7
 pdbufr==0.8.2
-Pillow==8.1.2
+Pillow==8.2.0
 Pint==0.16.1
 pngquant==1.0.6
 pooch==0.5.2


### PR DESCRIPTION
…ing 2 critical (CVE-2021-25287 et CVE-2021-25288)