### PR TITLE
feat: upgrade GDAL to 3.3.3 for compatibility with python 3.9.12

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -71,7 +71,7 @@
 | [g2clib](https://www.ncl.ucar.edu/) | 1.6.0 | scientific |
 | [gast](https://github.com/serge-sans-paille/gast/) | 0.4.0 | python3_scientific |
 | [GDAL](http://www.gdal.org) | 3.0.2 | python2_scientific |
-| [GDAL](http://www.gdal.org) | 3.0.2 | python3_scientific |
+| [GDAL](http://www.gdal.org) | 3.3.3 | python3_scientific |
 | [geopandas](http://geopandas.org) | 0.8.1 | python3_scientific |
 | [geos](https://github.com/grst/geos) | 0.2.2 | python3_scientific |
 | [gmt](https://www.generic-mapping-tools.org) | 6.2.0 | scientific |

--- a/integration_tests/0002_test_import_python3_scientific/import_python3_scientific.py
+++ b/integration_tests/0002_test_import_python3_scientific/import_python3_scientific.py
@@ -41,7 +41,8 @@ import flask
 import flit
 import fsspec
 import gast
-import gdal
+import osgeo #gdal
+import osgeo_utils #gdal
 import geopandas
 import geos
 import gmt

--- a/layers/layer4_python3_scientific/0500_extra_packages/requirements-to-freeze.txt
+++ b/layers/layer4_python3_scientific/0500_extra_packages/requirements-to-freeze.txt
@@ -37,7 +37,8 @@ pycoast
 pydecorate
 metview
 cdo
-GDAL==3.0.2
+#GDAL < 3.3.0 use invalid use_2to3 (python 3.9.12)
+GDAL>=3.3.0
 Fiona
 geopandas
 rasterio

--- a/layers/layer4_python3_scientific/0500_extra_packages/requirements3.txt
+++ b/layers/layer4_python3_scientific/0500_extra_packages/requirements3.txt
@@ -31,7 +31,7 @@ findlibs==0.0.2
 Fiona==1.8.13
 Flask==1.1.1
 fsspec==2021.10.1
-GDAL==3.0.2
+GDAL==3.3.3
 geopandas==0.8.1
 geos==0.2.2
 graphviz==0.11.1


### PR DESCRIPTION
(same 3.3.3 version as gdal library in mfext)