### PR TITLE
feat: upgrade scipy from 1.9.3 to 1.10.1 (security upgrade)

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -165,7 +165,7 @@
 | [scikit-build](https://github.com/scikit-build/scikit-build) | 0.16.2 | python3_scientific |
 | [scikit-image](https://scikit-image.org) | 0.19.3 | python3_scientific |
 | [scikit-learn](http://scikit-learn.org) | 1.1.3 | python3_scientific |
-| [scipy](https://scipy.org/) | 1.9.3 | python3_scientific |
+| [scipy](https://scipy.org/) | 1.10.1 | python3_scientific |
 | [scitools-iris](https://github.com/SciTools/iris) | 3.3.1 | python3_scientific |
 | [scitools-pyke](http://sourceforge.net/projects/pyke) | 1.1.1 | python3_scientific |
 | [seaborn](https://pypi.org/project/seaborn) | 0.12.1 | python3_scientific |

--- a/layers/layer4_python3_scientific/0499_prereq_extra_packages/allow_binary_packages
+++ b/layers/layer4_python3_scientific/0499_prereq_extra_packages/allow_binary_packages
@@ -1,1 +1,2 @@
 pkgconfig
+scipy

--- a/layers/layer4_python3_scientific/0499_prereq_extra_packages/requirements3.txt
+++ b/layers/layer4_python3_scientific/0499_prereq_extra_packages/requirements3.txt
@@ -5,7 +5,7 @@ flit==3.8.0
 maturin==0.14.10
 pkgconfig==1.5.5
 py-cpuinfo==9.0.0
-scipy==1.9.3
+scipy==1.10.1
 scitools-pyke==1.1.1
 setuptools-scm-git-archive==1.4
 tomli_w==1.0.0

--- a/layers/layer4_python3_scientific/0500_extra_packages/allow_binary_packages
+++ b/layers/layer4_python3_scientific/0500_extra_packages/allow_binary_packages
@@ -3,3 +3,4 @@ openturns
 llvmlite
 polars
 pyarrow
+scipy


### PR DESCRIPTION
(until we can upgrade gast, we use the binary wheel)