### PR TITLE
feat: upgrade fastparquet from 2023.10.1 to 2024.11.0

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -64,7 +64,7 @@
 | [faicons](https://github.com/rstudio/py-faicons) | 0.2.2 | python3_extratools |
 | [fasteners](https://github.com/harlowja/fasteners) | 0.19 | python3_scientific |
 | [fastjsonschema](https://github.com/horejsek/python-fastjsonschema) | 2.20.0 | python3_extratools |
-| [fastparquet](https://github.com/dask/fastparquet/) | 2023.10.1 | python3_scientific |
+| [fastparquet](https://github.com/dask/fastparquet/) | 2024.11.0 | python3_scientific |
 | [fckit](https://github.com/ecmwf/fckit) | 0.13.1 | scientific |
 | [FFmpeg](https://ffmpeg.org/) | 6.0 | scientific |
 | [ffmpy](https://github.com/Ch00k/ffmpy) | 0.3.1 | python3_scientific |

--- a/layers/layer4_python3_scientific/0500_extra_packages/requirements3.txt
+++ b/layers/layer4_python3_scientific/0500_extra_packages/requirements3.txt
@@ -38,7 +38,7 @@ eccodes==2.39.0
 ecmwf-api-client==1.6.3
 ecmwf-opendata==0.2.0
 fasteners==0.19
-fastparquet==2023.10.1
+fastparquet==2024.11.0
 ffmpy==0.3.1
 findlibs==0.0.5
 Fiona==1.10.0rc1

--- a/layers/layer4_python3_scientific/0630_esmf/version.patch
+++ b/layers/layer4_python3_scientific/0630_esmf/version.patch
@@ -10,13 +10,13 @@ diff -up esmf-8.6.0/src/addon/esmpy/pyproject.toml.orig esmf-8.6.0/src/addon/esm
  ]
 -dynamic = [ "version" ]
 +#dynamic = [ "version" ]
-+version = "8.6.0"
- 
++version = "8.7.0"
+
  [project.optional-dependencies]
  testing = [
 @@ -29,7 +30,8 @@ testing = [
  ]
- 
+
  [tool.setuptools-git-versioning]
 -enabled = true
 +#enabled = true


### PR DESCRIPTION
(compatibility numpy 2 and Python 3.13)