### PR TITLE
feat: upgrade llvmlite, numba, xclim to releases ok with Python 3.13

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -96,7 +96,6 @@
 | [httpcore](https://www.encode.io/httpcore/) | 1.0.6 | python3_extratools |
 | [httpx](https://github.com/encode/httpx) | 0.27.2 | python3_extratools |
 | [humanfriendly](https://humanfriendly.readthedocs.io) | 10.0 | python3_scientific |
-| [icclim](https://pypi.org/project/icclim) | 7.0.0 | python3_scientific |
 | [imageio](https://github.com/imageio/imageio) | 2.36.1 | python3_scientific |
 | [ImageMagick6](http://www.imagemagick.org) | 6.9.13-16 | scientific |
 | [ipykernel](https://ipython.org) | 6.29.5 | python3_extratools |
@@ -124,7 +123,7 @@
 | [kiwisolver](https://github.com/nucleic/kiwi) | 1.4.5 | python3_scientific |
 | [lazy_loader](https://pypi.org/project/lazy_loader) | 0.3 | python3_scientific |
 | [linkify-it-py](https://github.com/tsutsu3/linkify-it-py) | 2.0.3 | python3_extratools |
-| [llvmlite](http://llvmlite.readthedocs.io) | 0.43.0 | python3_scientific |
+| [llvmlite](http://llvmlite.readthedocs.io) | 0.44.0rc2 | python3_scientific |
 | [lmoments3](https://lmoments3.readthedocs.io/en) | 1.0.6 | python3_scientific |
 | [locket](http://github.com/mwilliamson/locket.py) | 1.0.0 | python3_scientific |
 | [lru-dict](https://github.com/amitdev/lru-dict) | 1.3.0 | python3_scientific |
@@ -159,7 +158,7 @@
 | [ninja](http://ninja-build.org/) | 1.11.1.1 | python3_scientific |
 | [notebook](https://github.com/jupyter/notebook) | 7.2.2 | python3_extratools |
 | [notebook_shim](https://pypi.org/project/notebook_shim) | 0.2.4 | python3_extratools |
-| [numba](https://numba.pydata.org) | 0.60.0 | python3_scientific |
+| [numba](https://numba.pydata.org) | 0.61.0rc1 | python3_scientific |
 | [numcodecs](https://github.com/zarr-developers/numcodecs) | 0.12.1 | python3_scientific |
 | [numexpr](https://github.com/pydata/numexpr) | 2.10.1 | python3_scientific |
 | [numpngw](https://github.com/WarrenWeckesser/numpngw) | 0.1.3 | python3_scientific |
@@ -272,7 +271,7 @@
 | [widgetsnbextension](http://jupyter.org) | 4.0.13 | python3_extratools |
 | [windrose](https://github.com/python-windrose/windrose) | 1.9.0 | python3_scientific |
 | [xarray](https://xarray.dev/) | 2024.11.0 | python3_scientific |
-| [xclim](https://xclim.readthedocs.io/) | 0.48.0 | python3_scientific |
+| [xclim](https://xclim.readthedocs.io/) | 0.48.2 | python3_scientific |
 | [XlsxWriter](https://github.com/jmcnamara/XlsxWriter) | 3.1.9 | python3_extratools |
 | [xxhash](https://github.com/ifduyue/python-xxhash) | 3.4.1 | python3_scientific |
 | [xyzservices](https://github.com/geopandas/xyzservices) | 2023.10.0 | python3_scientific |
@@ -280,4 +279,4 @@
 | [zarr](https://github.com/zarr-developers/zarr-python) | 2.16.1 | python3_scientific |
 | [zict](http://zict.readthedocs.io/en/latest/) | 3.0.0 | python3_scientific |
 
-*(279 components)*
+*(278 components)*

--- a/layers/layer4_python3_scientific/0500_extra_packages/requirements-to-freeze.txt
+++ b/layers/layer4_python3_scientific/0500_extra_packages/requirements-to-freeze.txt
@@ -70,7 +70,7 @@ statsmodels
 bokeh
 astropy
 #note : icclim 7.0.0 requires xclim>=0.45,<=0.48
-icclim
+#icclim (temporarly removed for Python 3.13 compatibility)
 protobuf
 xclim
 Pint

--- a/layers/layer4_python3_scientific/0500_extra_packages/requirements3.txt
+++ b/layers/layer4_python3_scientific/0500_extra_packages/requirements3.txt
@@ -58,7 +58,6 @@ greenlet==3.1.1
 humanfriendly==10.0
 h5py==3.12.1
 HeapDict==1.0.1
-icclim==7.0.0
 imageio==2.36.1
 ipython-genutils==0.2.0
 itsdangerous==2.1.2
@@ -66,7 +65,7 @@ jsmin==3.0.1
 jsonpickle==3.0.2
 kiwisolver==1.4.5
 lazy-loader==0.3
-llvmlite==0.43.0
+llvmlite==0.44.0rc2
 lmoments3==1.0.6
 locket==1.0.0
 lru-dict==1.3.0
@@ -83,7 +82,7 @@ multiurl==0.3.3
 munch==4.0.0
 nco==1.1.0
 netCDF4==1.6.4
-numba==0.60.0
+numba==0.61.0rc1
 numcodecs==0.12.1
 numexpr==2.10.1
 numpngw==0.1.3
@@ -149,7 +148,7 @@ toolz==0.12.0
 trollimage==1.21.0
 trollsift==0.5.1
 tzlocal==5.2
-xclim==0.48.0
+xclim==0.48.2
 xxhash==3.4.1
 xyzservices==2023.10.0
 windrose==1.9.0


### PR DESCRIPTION
(and temporarly removed icclim, waiting new release)