### PR TITLE
feat: bump scikit-build from 0.16.2 to 0.18.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /layers/layer*/*_extra_python_packages*/src
 /layers/layer*/*_extra_python_packages*/tempolayer*
 /layers/layer*/cache
+layers/layer1_scientific/0003_libimagequant/imagequant.pc
 
 
 doc/_build

--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -229,7 +229,7 @@
 | [Rtree](https://pypi.org/project/Rtree) | 1.1.0 | python3_scientific |
 | [salem](https://salem.readthedocs.io) | 0.3.11 | python3_scientific |
 | [satpy](https://github.com/pytroll/satpy) | 0.44.0 | python3_scientific |
-| [scikit-build](https://github.com/scikit-build/scikit-build) | 0.16.2 | python3_scientific |
+| [scikit-build](https://github.com/scikit-build/scikit-build) | 0.18.1 | python3_scientific |
 | [scikit-image](https://scikit-image.org) | 0.25.0 | python3_scientific |
 | [scikit-learn](https://scikit-learn.org) | 1.5.0 | python3_scientific |
 | [scipy](https://scipy.org/) | 1.14.1 | python3_scientific |

--- a/layers/layer4_python3_scientific/0495_prereq_extra_packages/requirements3.txt
+++ b/layers/layer4_python3_scientific/0495_prereq_extra_packages/requirements3.txt
@@ -1,3 +1,3 @@
 meson==1.3.1
 pyproject_metadata==0.7.1
-scikit-build==0.16.2
+scikit-build==0.18.1


### PR DESCRIPTION
(do not use anymore deprecated setuptools.command.test)