### PR TITLE
feat: bump zarr to 2.18.7 and downgrade numcodecs to 0.15.1

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -181,7 +181,7 @@
 | [notebook](https://github.com/jupyter/notebook) | 7.2.2 | python3_extratools |
 | [notebook_shim](https://pypi.org/project/notebook_shim) | 0.2.4 | python3_extratools |
 | [numba](https://numba.pydata.org) | 0.61.2 | python3_scientific |
-| [numcodecs](https://github.com/zarr-developers/numcodecs) | 0.16.0 | python3_scientific |
+| [numcodecs](https://github.com/zarr-developers/numcodecs) | 0.15.1 | python3_scientific |
 | [numexpr](https://github.com/pydata/numexpr) | 2.10.2 | python3_scientific |
 | [numpngw](https://github.com/WarrenWeckesser/numpngw) | 0.1.4 | python3_scientific |
 | [numpy](https://numpy.org) | 2.1.3 | python3_scientific |
@@ -308,7 +308,7 @@
 | [xxhash](https://github.com/ifduyue/python-xxhash) | 3.4.1 | python3_scientific |
 | [xyzservices](https://github.com/geopandas/xyzservices) | 2023.10.0 | python3_scientific |
 | [yamale](https://github.com/23andMe/Yamale) | 5.2.1 | python3_scientific |
-| [zarr](https://github.com/zarr-developers/zarr-python) | 2.16.1 | python3_scientific |
+| [zarr](https://github.com/zarr-developers/zarr-python) | 2.18.7 | python3_scientific |
 | [zict](http://zict.readthedocs.io/en/latest/) | 3.0.0 | python3_scientific |
 | [zope.interface](https://github.com/zopefoundation/zope.interface) | 7.2 | python3_scientific |
 

--- a/layers/layer4_python3_scientific/0500_extra_packages/requirements3.txt
+++ b/layers/layer4_python3_scientific/0500_extra_packages/requirements3.txt
@@ -101,7 +101,7 @@ narwhals==1.37.0
 nco==1.1.2
 netCDF4==1.7.2
 numba==0.61.2
-numcodecs==0.16.0
+numcodecs==0.15.1
 numexpr==2.10.2
 numpngw==0.1.4
 opencv-contrib-python-headless==4.11.0.86
@@ -177,6 +177,6 @@ xxhash==3.4.1
 xyzservices==2023.10.0
 windrose==1.9.0
 yamale==5.2.1
-zarr==2.16.1
+zarr==2.18.7
 zict==3.0.0
 zope.interface==7.2


### PR DESCRIPTION
(compatibility copernicusmarine 2.0.1)