### PR TITLE
feat: revert "feat: build ImageMagick6 with option --with-gslib"

### DIFF
--- a/layers/layer1_scientific/0040_imagemagick6/Makefile.mk
+++ b/layers/layer1_scientific/0040_imagemagick6/Makefile.mk
@@ -15,4 +15,4 @@ LICENSE=Apache 2.0
 # Upgrade to ImageMagick 7 ?
 all:: $(PREFIX)/bin/convert
 $(PREFIX)/bin/convert:
-	$(MAKE) --file=$(MFEXT_HOME)/share/Makefile.standard PREFIX=$(PREFIX) ARCHIV=$(ARCHIV) EXTRALDFLAGS="-L$(PREFIX)/../core/lib" EXTRACFLAGS="-I$(PREFIX)/../core/include" OPTIONS="--disable-static --with-rsvg --with-gslib" download uncompress configure build install
+	$(MAKE) --file=$(MFEXT_HOME)/share/Makefile.standard PREFIX=$(PREFIX) ARCHIV=$(ARCHIV) EXTRALDFLAGS="-L$(PREFIX)/../core/lib" EXTRACFLAGS="-I$(PREFIX)/../core/include" OPTIONS="--disable-static --with-rsvg" download uncompress configure build install


### PR DESCRIPTION
(conflict between libtiff.so.5 required by libgs.so.9 and libtiff.so.6 provided by layer core)