### PR TITLE
feat: bump copernicusmarine from 2.0.1 to 2.1.0

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -5,6 +5,7 @@
 | [aggdraw](https://github.com/pytroll/aggdraw) | 1.3.19 | python3_scientific |
 | [anyio](https://pypi.org/project/anyio) | 3.5.0 | python3_extratools |
 | [apng](https://github.com/eight04/pyAPNG) | 0.3.4 | python3_scientific |
+| [arcosparse](https://pypi.org/project/arcosparse) | 0.4.0 | python3_scientific |
 | [argon2-cffi-bindings](https://github.com/hynek/argon2-cffi-bindings) | 21.2.0 | python3_extratools |
 | [argon2-cffi](https://pypi.org/project/argon2-cffi) | 23.1.0 | python3_extratools |
 | [array_api_compat](https://data-apis.org/array-api-compat/) | 1.11.2 | python3_scientific |
@@ -40,7 +41,7 @@
 | [configobj](https://github.com/DiffSK/configobj) | 5.0.9 | python3_scientific |
 | [conflator](https://pypi.org/project/conflator) | 0.1.7 | python3_scientific |
 | [contourpy](https://github.com/contourpy/contourpy) | 1.3.2 | python3_scientific |
-| [copernicusmarine](https://pypi.org/project/copernicusmarine) | 2.0.1 | python3_scientific |
+| [copernicusmarine](https://pypi.org/project/copernicusmarine) | 2.1.0 | python3_scientific |
 | [covjson-pydantic](https://pypi.org/project/covjson-pydantic) | 0.6.0 | python3_scientific |
 | [covjsonkit](https://github.com/ecmwf/covjsonkit) | 0.1.9 | python3_scientific |
 | [cppy](https://github.com/nucleic/cppy) | 1.3.1 | python3_scientific |
@@ -314,4 +315,4 @@
 | [zict](http://zict.readthedocs.io/en/latest/) | 3.0.0 | python3_scientific |
 | [zope.interface](https://github.com/zopefoundation/zope.interface) | 7.2 | python3_scientific |
 
-*(313 components)*
+*(314 components)*

--- a/integration_tests/0002_test_import_python3_scientific/import_python3_scientific.py
+++ b/integration_tests/0002_test_import_python3_scientific/import_python3_scientific.py
@@ -2,6 +2,7 @@ import adjustText
 import affine
 import aggdraw
 import apng
+import arcosparse
 import array_api_compat
 import asciitree
 import astropy

--- a/layers/layer4_python3_scientific/0500_extra_packages/allow_binary_packages
+++ b/layers/layer4_python3_scientific/0500_extra_packages/allow_binary_packages
@@ -1,3 +1,4 @@
+arcosparse
 bokeh
 cdo
 conflator

--- a/layers/layer4_python3_scientific/0500_extra_packages/requirements3.txt
+++ b/layers/layer4_python3_scientific/0500_extra_packages/requirements3.txt
@@ -2,6 +2,7 @@ adjustText==1.3.0
 affine==2.4.0
 aggdraw==1.3.19
 apng==0.3.4
+arcosparse==0.4.0
 argparse==1.4.0
 array_api_compat==1.11.2
 asciitree==0.3.3
@@ -29,7 +30,7 @@ coloredlogs==15.0.1
 configobj==5.0.9
 conflator==0.1.7
 contourpy==1.3.2
-copernicusmarine==2.0.1
+copernicusmarine==2.1.0
 covjson_pydantic==0.6.0
 covjsonkit==0.1.9
 cramjam==2.10.0


### PR DESCRIPTION
(also add dependency arcosparse 0.4.0)