### PR TITLE
feat: bump s3transfer from 0.11.2 to 0.12.0

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -20,8 +20,8 @@
 | [blinker](https://pypi.org/project/blinker) | 1.9.0 | python3_scientific |
 | [bokeh](https://bokeh.org) | 3.7.2 | python3_scientific |
 | [boltons](https://github.com/mahmoud/boltons) | 25.0.0 | python3_scientific |
-| [boto3](https://github.com/boto/boto3) | 1.37.35 | python3_scientific |
-| [botocore](https://github.com/boto/botocore) | 1.37.35 | python3_scientific |
+| [boto3](https://github.com/boto/boto3) | 1.38.11 | python3_scientific |
+| [botocore](https://github.com/boto/botocore) | 1.38.11 | python3_scientific |
 | [Bottleneck](https://github.com/pydata/bottleneck) | 1.4.2 | python3_scientific |
 | [branca](https://github.com/python-visualization/branca) | 0.8.1 | python3_scientific |
 | [Cartopy](https://github.com/SciTools/cartopy) | 0.24.1 | python3_scientific |
@@ -257,7 +257,7 @@
 | [rfc3986_validator](https://github.com/naimetti/rfc3986-validator) | 0.1.1 | python3_extratools |
 | [rich-argparse](https://github.com/hamdanal/rich-argparse) | 1.7.0 | python3_scientific |
 | [rtree](https://pypi.org/project/rtree) | 1.4.0 | python3_scientific |
-| [s3transfer](https://github.com/boto/s3transfer) | 0.11.2 | python3_scientific |
+| [s3transfer](https://github.com/boto/s3transfer) | 0.12.0 | python3_scientific |
 | [salem](https://salem.readthedocs.io) | 0.3.11 | python3_scientific |
 | [satpy](https://github.com/pytroll/satpy) | 0.44.0 | python3_scientific |
 | [scikit-build](https://github.com/scikit-build/scikit-build) | 0.18.1 | python3_scientific |

--- a/layers/layer4_python3_scientific/0500_extra_packages/requirements3.txt
+++ b/layers/layer4_python3_scientific/0500_extra_packages/requirements3.txt
@@ -12,8 +12,8 @@ blinker==1.9.0
 bokeh==3.7.2
 boltons==25.0.0
 Bottleneck==1.4.2
-boto3==1.37.35
-botocore==1.37.35
+boto3==1.38.11
+botocore==1.38.11
 branca==0.8.1
 Cartopy==0.24.1
 cdo==1.6.1
@@ -154,7 +154,7 @@ regionmask==0.13.0
 reportlab==4.4.0
 rich-argparse==1.7.0
 rtree==1.4.0
-s3transfer==0.11.2
+s3transfer==0.12.0
 salem==0.3.11
 satpy==0.44.0
 scikit-image==0.25.0


### PR DESCRIPTION
(also bump boto and boto3 from 1.37.35 to 1.38.11 for compatibility)