### PR TITLE
build: remove snuggs (not required anymore by Fiona and rasterio)

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -275,7 +275,6 @@
 | [shiny](https://github.com/posit-dev/py-shiny) | 1.0.0 | python3_extratools |
 | [simpervisor](https://pypi.org/project/simpervisor) | 1.0.0 | python3_extratools |
 | [sniffio](https://github.com/python-trio/sniffio) | 1.2.0 | python3_extratools |
-| [snuggs](https://github.com/mapbox/snuggs) | 1.4.7 | python3_scientific |
 | [spatialindex](https://libspatialindex.org) | 2.1.0 | scientific |
 | [SQLAlchemy](https://www.sqlalchemy.org) | 2.0.36 | python3_scientific |
 | [starlette](https://github.com/encode/starlette) | 0.41.0 | python3_extratools |
@@ -315,4 +314,4 @@
 | [zict](http://zict.readthedocs.io/en/latest/) | 3.0.0 | python3_scientific |
 | [zope.interface](https://github.com/zopefoundation/zope.interface) | 7.2 | python3_scientific |
 
-*(314 components)*
+*(313 components)*

--- a/layers/layer4_python3_scientific/0500_extra_packages/requirements3.txt
+++ b/layers/layer4_python3_scientific/0500_extra_packages/requirements3.txt
@@ -164,7 +164,6 @@ scores==2.1.0
 seaborn==0.13.2
 semver==3.0.4
 Shapely==2.1.0
-snuggs==1.4.7
 SQLAlchemy==2.0.36
 statsmodels==0.14.2
 tblib==3.0.0


### PR DESCRIPTION
Note: rasterio and Fiona are now including a modified version of snuggs 1.4.7