### PR TITLE
feat: bump protobuf from 3.20.3 to 5.29.4 with binary build

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -158,7 +158,7 @@
 | [pooch](https://pypi.org/project/pooch) | 1.8.2 | python3_scientific |
 | [pox](https://github.com/uqfoundation/pox) | 0.3.6 | python3_scientific |
 | [ppft](https://github.com/uqfoundation/ppft) | 1.7.7 | python3_scientific |
-| [protobuf](https://developers.google.com/protocol-buffers/) | 3.20.3 | python3_scientific |
+| [protobuf](https://developers.google.com/protocol-buffers/) | 5.29.4 | python3_scientific |
 | [puremagic](https://github.com/cdgriffith/puremagic) | 1.29 | python3_scientific |
 | [py-cpuinfo](https://github.com/workhorsy/py-cpuinfo) | 9.0.0 | python3_scientific |
 | [pyarrow](https://arrow.apache.org/) | 20.0.0 | python3_scientific |

--- a/layers/layer4_python3_scientific/0500_extra_packages/allow_binary_packages
+++ b/layers/layer4_python3_scientific/0500_extra_packages/allow_binary_packages
@@ -14,6 +14,7 @@ llvmlite
 odclib
 orjson
 polars
+protobuf
 pyarrow
 pyYAML
 rich

--- a/layers/layer4_python3_scientific/0500_extra_packages/requirements-to-freeze.txt
+++ b/layers/layer4_python3_scientific/0500_extra_packages/requirements-to-freeze.txt
@@ -69,7 +69,8 @@ bokeh
 astropy
 #note : icclim 7.0.0 requires xclim>=0.45,<=0.48
 #icclim (temporarly removed for Python 3.13 compatibility)
-protobuf
+#tensorflow 2.19.0 requires protbuf < 6
+protobuf<6
 xclim
 Pint
 pyoscar

--- a/layers/layer4_python3_scientific/0500_extra_packages/requirements3.txt
+++ b/layers/layer4_python3_scientific/0500_extra_packages/requirements3.txt
@@ -123,7 +123,7 @@ polytope-client==0.7.4
 pooch==1.8.2
 pox==0.3.6
 ppft==1.7.7
-protobuf==3.20.3
+protobuf==5.29.4
 puremagic==1.29
 pyarrow==20.0.0
 pycoast==1.7.1


### PR DESCRIPTION
(there are difficulties to build from sources because of protobuf built from sources)