### PR TITLE
feat: bump xarray from 2025.3.1 to 2025.8.0

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -226,7 +226,7 @@
 | [udunits](http://www.unidata.ucar.edu/software/udunits) | 2.2.28 | scientific |
 | [versioneer](https://github.com/python-versioneer/python-versioneer) | 0.29 | python3_scientific |
 | [windrose](https://github.com/python-windrose/windrose) | 1.9.2 | python3_scientific |
-| [xarray](https://xarray.dev/) | 2025.3.1 | python3_scientific |
+| [xarray](https://xarray.dev/) | 2025.8.0 | python3_scientific |
 | [xclim](https://xclim.readthedocs.io/) | 0.57.0 | python3_scientific |
 | [xsdba](https://xsdba.readthedocs.io/) | 0.4.0 | python3_scientific |
 | [xxhash](https://github.com/ifduyue/python-xxhash) | 3.5.0 | python3_scientific |

--- a/layers/layer4_python3_scientific/0499_prereq_extra_packages/requirements3.txt
+++ b/layers/layer4_python3_scientific/0499_prereq_extra_packages/requirements3.txt
@@ -9,4 +9,4 @@ scitools-pyke==1.1.1
 scipy==1.15.3
 tomli_w==1.2.0
 tzdata==2025.2
-xarray==2025.3.1
+xarray==2025.8.0


### PR DESCRIPTION
(compatibility zarr3 and numpy 2.3)