### PR TITLE
feat: bump ImageMagick6 to 6.9.13-44 (fix 6 moderate CVE)

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -107,7 +107,7 @@
 | [humanize](https://github.com/python-humanize/humanize) | 4.15.0 | python3_scientific |
 | [icclim](https://pypi.org/project/icclim) | 7.0.5 | python3_scientific |
 | [imageio](https://github.com/imageio/imageio) | 2.37.0 | python3_scientific |
-| [ImageMagick6](http://www.imagemagick.org) | 6.9.13-43 | scientific |
+| [ImageMagick6](http://www.imagemagick.org) | 6.9.13-44 | scientific |
 | [itsdangerous](https://pypi.org/project/itsdangerous) | 2.2.0 | python3_scientific |
 | [jsmin](https://github.com/tikitu/jsmin/) | 3.0.1 | python3_scientific |
 | [kiwisolver](https://github.com/nucleic/kiwi) | 1.4.8 | python3_scientific |

--- a/layers/layer1_scientific/0040_imagemagick6/Makefile.mk
+++ b/layers/layer1_scientific/0040_imagemagick6/Makefile.mk
@@ -2,10 +2,10 @@ include ../../../adm/root.mk
 include $(MFEXT_HOME)/share/package.mk
 
 export NAME=ImageMagick6
-export VERSION=6.9.13-43
+export VERSION=6.9.13-44
 export EXTENSION=tar.gz
 export CHECKTYPE=MD5
-export CHECKSUM=c588f790a5c11ee17a65d23a56b1a6d1
+export CHECKSUM=924f6b8b9b2364e8dc4d8b1546c0817e
 export ARCHIV=$(VERSION).$(EXTENSION)
 DESCRIPTION=\
 IMAGEMAGICK is a software suite to create, edit, compose, or convert images.

--- a/layers/layer1_scientific/0040_imagemagick6/sources
+++ b/layers/layer1_scientific/0040_imagemagick6/sources
@@ -1,1 +1,1 @@
-https://github.com/ImageMagick/ImageMagick6/archive/6.9.13-43.tar.gz
+https://github.com/ImageMagick/ImageMagick6/archive/6.9.13-44.tar.gz


### PR DESCRIPTION
CVE fixed :
- CVE-2026-33899
- CVE-2026-33900
- CVE-2026-34238
- CVE-2026-40310
- CVE-2026-40311
- CVE-2026-40312