### PR TITLE
feat: bump xarray from 2025.8.0 to 2026.4.0

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -193,7 +193,7 @@
 | [rasterio](https://pypi.org/project/rasterio) | 1.5.0 | python3_scientific |
 | [regionmask](https://github.com/regionmask/regionmask) | 0.13.0 | python3_scientific |
 | [rich-argparse](https://github.com/hamdanal/rich-argparse) | 1.7.0 | python3_scientific |
-| [rioxarray](https://corteva.github.io/rioxarray/) | 0.21.0 | python3_scientific |
+| [rioxarray](https://corteva.github.io/rioxarray/) | 0.22.0 | python3_scientific |
 | [rtree](https://pypi.org/project/rtree) | 1.4.0 | python3_scientific |
 | [s3transfer](https://github.com/boto/s3transfer) | 0.12.0 | python3_scientific |
 | [salem](https://salem.readthedocs.io) | 0.3.11 | python3_scientific |
@@ -221,7 +221,7 @@
 | [tzlocal](https://pypi.org/project/tzlocal) | 5.3.1 | python3_scientific |
 | [udunits](http://www.unidata.ucar.edu/software/udunits) | 2.2.28 | scientific |
 | [windrose](https://github.com/python-windrose/windrose) | 1.9.2 | python3_scientific |
-| [xarray](https://xarray.dev/) | 2025.8.0 | python3_scientific |
+| [xarray](https://xarray.dev/) | 2026.4.0 | python3_scientific |
 | [xclim](https://xclim.readthedocs.io/) | 0.60.0 | python3_scientific |
 | [xsdba](https://xsdba.readthedocs.io/) | 0.4.0 | python3_scientific |
 | [xxhash](https://github.com/ifduyue/python-xxhash) | 3.5.0 | python3_scientific |

--- a/layers/layer4_python3_scientific/0400_prereq_extra_packages/requirements3.txt
+++ b/layers/layer4_python3_scientific/0400_prereq_extra_packages/requirements3.txt
@@ -2,4 +2,4 @@ numpy==2.4.6
 pandas==2.3.3
 scipy==1.17.1
 tzdata==2025.2
-xarray==2025.8.0
+xarray==2026.4.0

--- a/layers/layer4_python3_scientific/0500_extra_packages/requirements3.txt
+++ b/layers/layer4_python3_scientific/0500_extra_packages/requirements3.txt
@@ -169,7 +169,7 @@ qubed==0.3.1
 rasterio==1.5.0
 regionmask==0.13.0
 rich-argparse==1.7.0
-rioxarray==0.21.0
+rioxarray==0.22.0
 rtree==1.4.0
 s3transfer==0.12.0
 salem==0.3.11


### PR DESCRIPTION
requiring to bump rioxarray from 0.21.0 to 0.22.0